### PR TITLE
MTDSA-16151: Copy V1 Get Crystallisation to V2

### DIFF
--- a/app/v1/services/BaseService.scala
+++ b/app/v1/services/BaseService.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1.services
+
+import api.controllers.RequestContextImplicits
+import v1.support.DownstreamResponseMappingSupport
+import utils.Logging
+
+trait BaseService extends RequestContextImplicits with DownstreamResponseMappingSupport with Logging

--- a/app/v1/services/RetrieveCrystallisationObligationsService.scala
+++ b/app/v1/services/RetrieveCrystallisationObligationsService.scala
@@ -18,7 +18,7 @@ package v1.services
 
 import api.controllers.RequestContext
 import api.models.errors._
-import api.services.{ BaseService, ServiceOutcome }
+import api.services.ServiceOutcome
 import cats.data.EitherT
 import cats.implicits._
 import v1.connectors.RetrieveCrystallisationObligationsConnector

--- a/app/v1/services/RetrievePeriodicObligationsService.scala
+++ b/app/v1/services/RetrievePeriodicObligationsService.scala
@@ -18,7 +18,7 @@ package v1.services
 
 import api.controllers.RequestContext
 import api.models.errors._
-import api.services.{ BaseService, ServiceOutcome }
+import api.services.ServiceOutcome
 import cats.data.EitherT
 import cats.implicits._
 import v1.connectors.RetrievePeriodicObligationsConnector

--- a/app/v1/support/DownstreamResponseMappingSupport.scala
+++ b/app/v1/support/DownstreamResponseMappingSupport.scala
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1.support
+
+import api.controllers.EndpointLogContext
+import api.models.domain.business.MtdBusiness
+import api.models.errors._
+import api.models.outcomes.ResponseWrapper
+import utils.Logging
+import v1.models.response.retrieveCrystallisationObligations.RetrieveCrystallisationObligationsResponse
+import v1.models.response.retrieveCrystallisationObligations.des.DesRetrieveCrystallisationObligationsResponse
+import v1.models.response.retrieveEOPSObligations.RetrieveEOPSObligationsResponse
+import v1.models.response.retrievePeriodicObligations.RetrievePeriodObligationsResponse
+
+trait DownstreamResponseMappingSupport {
+  self: Logging =>
+
+  final def filterPeriodicValues(
+      responseWrapper: ResponseWrapper[RetrievePeriodObligationsResponse],
+      typeOfBusiness: Option[MtdBusiness],
+      businessId: Option[String]
+  ): Either[ErrorWrapper, ResponseWrapper[RetrievePeriodObligationsResponse]] = {
+    val filteredObligations = responseWrapper.responseData.obligations
+      .filter { obligation =>
+        typeOfBusiness.forall(_ == obligation.typeOfBusiness)
+      }
+      .filter { obligation =>
+        businessId.forall(_ == obligation.businessId)
+      }
+      .filter { obligation =>
+        obligation.obligationDetails.nonEmpty
+      }
+
+    if (filteredObligations.nonEmpty) {
+      Right(ResponseWrapper(responseWrapper.correlationId, RetrievePeriodObligationsResponse(filteredObligations)))
+    } else {
+      Left(ErrorWrapper(responseWrapper.correlationId, NoObligationsFoundError))
+    }
+  }
+
+  final def filterEOPSValues(
+      responseWrapper: ResponseWrapper[RetrieveEOPSObligationsResponse],
+      typeOfBusiness: Option[MtdBusiness],
+      businessId: Option[String]
+  ): Either[ErrorWrapper, ResponseWrapper[RetrieveEOPSObligationsResponse]] = {
+
+    val filteredObligations = responseWrapper.responseData.obligations
+      .filter { obligation =>
+        typeOfBusiness.forall(_ == obligation.typeOfBusiness)
+      }
+      .filter { obligation =>
+        businessId.forall(_ == obligation.businessId)
+      }
+      .filter { obligation =>
+        obligation.obligationDetails.nonEmpty
+      }
+
+    if (filteredObligations.nonEmpty) {
+      Right(ResponseWrapper(responseWrapper.correlationId, RetrieveEOPSObligationsResponse(filteredObligations)))
+    } else {
+      Left(ErrorWrapper(responseWrapper.correlationId, NoObligationsFoundError))
+    }
+  }
+
+  final def filterCrystallisationValues(
+      responseWrapper: ResponseWrapper[DesRetrieveCrystallisationObligationsResponse]
+  ): Either[ErrorWrapper, ResponseWrapper[RetrieveCrystallisationObligationsResponse]] = {
+    responseWrapper.responseData.obligationDetails.toList match {
+      case desO :: Nil =>
+        Right(ResponseWrapper(responseWrapper.correlationId, desO.toMtd))
+      case Nil    => Left(ErrorWrapper(responseWrapper.correlationId, NoObligationsFoundError))
+      case _ :: _ => Left(ErrorWrapper(responseWrapper.correlationId, InternalError))
+    }
+  }
+
+  final def mapDownstreamErrors[_](errorCodeMap: PartialFunction[String, MtdError])(downstreamResponseWrapper: ResponseWrapper[DownstreamError])(
+      implicit logContext: EndpointLogContext): ErrorWrapper = {
+
+    lazy val defaultErrorCodeMapping: String => MtdError = { code =>
+      logger.warn(s"[${logContext.controllerName}] [${logContext.endpointName}] - No mapping found for error code $code")
+      InternalError
+    }
+
+    downstreamResponseWrapper match {
+      case ResponseWrapper(correlationId, DownstreamErrors(error :: Nil)) =>
+        ErrorWrapper(correlationId, errorCodeMap.applyOrElse(error.code, defaultErrorCodeMapping), None)
+
+      case ResponseWrapper(correlationId, DownstreamErrors(errorCodes)) =>
+        val mtdErrors = errorCodes.map(error => errorCodeMap.applyOrElse(error.code, defaultErrorCodeMapping))
+
+        if (mtdErrors.contains(InternalError)) {
+          logger.warn(
+            s"[${logContext.controllerName}] [${logContext.endpointName}] [CorrelationId - $correlationId]" +
+              s" - downstream returned ${errorCodes.map(_.code).mkString(",")}. Revert to ISE")
+          ErrorWrapper(correlationId, InternalError, None)
+        } else {
+          ErrorWrapper(correlationId, BadRequestError, Some(mtdErrors))
+        }
+
+      case ResponseWrapper(correlationId, OutboundError(error, errors)) =>
+        ErrorWrapper(correlationId, error, errors)
+    }
+  }
+}

--- a/app/v2/connectors/RetrieveCrystallisationObligationsConnector.scala
+++ b/app/v2/connectors/RetrieveCrystallisationObligationsConnector.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.connectors
+
+import api.connectors.DownstreamUri._
+import api.connectors.httpparsers.StandardDownstreamHttpParser._
+import api.connectors.{BaseDownstreamConnector, DownstreamOutcome}
+import config.AppConfig
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
+import v2.models.request.retrieveCrystallisationObligations.RetrieveCrystallisationObligationsRequest
+import v2.models.response.retrieveCrystallisationObligations.des.DesRetrieveCrystallisationObligationsResponse
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class RetrieveCrystallisationObligationsConnector @Inject()(val http: HttpClient, val appConfig: AppConfig) extends BaseDownstreamConnector {
+
+  def retrieveCrystallisationObligations(request: RetrieveCrystallisationObligationsRequest)(
+      implicit
+      hc: HeaderCarrier,
+      ec: ExecutionContext,
+      correlationId: String): Future[DownstreamOutcome[DesRetrieveCrystallisationObligationsResponse]] = {
+
+    import request._
+
+    val url = DesUri[DesRetrieveCrystallisationObligationsResponse](
+      s"enterprise/obligation-data/nino/$nino/ITSA?from=${obligationsTaxYear.from}&to=${obligationsTaxYear.to}")
+
+    get(url)
+  }
+}

--- a/app/v2/controllers/RetrieveCrystallisationObligationsController.scala
+++ b/app/v2/controllers/RetrieveCrystallisationObligationsController.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.controllers
+
+import api.controllers._
+import api.services.{AuditService, EnrolmentsAuthService, MtdIdLookupService}
+import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import utils.{IdGenerator, Logging}
+import v2.controllers.requestParsers.RetrieveCrystallisationObligationsRequestParser
+import v2.models.request.retrieveCrystallisationObligations.RetrieveCrystallisationObligationsRawData
+import v2.services._
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class RetrieveCrystallisationObligationsController @Inject()(val authService: EnrolmentsAuthService,
+                                                             val lookupService: MtdIdLookupService,
+                                                             parser: RetrieveCrystallisationObligationsRequestParser,
+                                                             service: RetrieveCrystallisationObligationsService,
+                                                             auditService: AuditService,
+                                                             cc: ControllerComponents,
+                                                             idGenerator: IdGenerator)(implicit ec: ExecutionContext)
+    extends AuthorisedController(cc)
+    with Logging {
+
+  implicit val endpointLogContext: EndpointLogContext =
+    EndpointLogContext(controllerName = "RetrieveCrystallisationObligationsController", endpointName = "retrieveCrystallisationObligations")
+
+  def handleRequest(nino: String, taxYear: Option[String]): Action[AnyContent] =
+    authorisedAction(nino).async { implicit request =>
+      implicit val ctx: RequestContext = RequestContext.from(idGenerator, endpointLogContext)
+
+      val rawData = RetrieveCrystallisationObligationsRawData(nino, taxYear)
+
+      val requestHandler = RequestHandler
+        .withParser(parser)
+        .withService(service.retrieve)
+        .withPlainJsonResult()
+        .withAuditing(AuditHandler(
+          auditService = auditService,
+          auditType = "RetrieveCrystallisationObligations",
+          transactionName = "retrieve-crystallisation-obligations",
+          pathParams = Map("nino" -> nino),
+          includeResponse = true
+        ))
+
+      requestHandler.handleRequest(rawData)
+    }
+
+}

--- a/app/v2/controllers/requestParsers/RetrieveCrystallisationObligationsRequestParser.scala
+++ b/app/v2/controllers/requestParsers/RetrieveCrystallisationObligationsRequestParser.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.controllers.requestParsers
+
+import api.controllers.requestParsers.RequestParser
+import api.models.domain.Nino
+import v2.controllers.requestParsers.validators.RetrieveCrystallisationObligationsValidator
+import v2.models.request.retrieveCrystallisationObligations.{RetrieveCrystallisationObligationsRawData, RetrieveCrystallisationObligationsRequest}
+import v2.models.request.{ObligationsTaxYear, ObligationsTaxYearHelpers}
+
+import javax.inject.Inject
+
+class RetrieveCrystallisationObligationsRequestParser @Inject()(val validator: RetrieveCrystallisationObligationsValidator)
+    extends RequestParser[RetrieveCrystallisationObligationsRawData, RetrieveCrystallisationObligationsRequest]
+    with ObligationsTaxYearHelpers {
+
+  override protected def requestFor(data: RetrieveCrystallisationObligationsRawData): RetrieveCrystallisationObligationsRequest = {
+    val obligationsTaxYear: ObligationsTaxYear = RawTaxYear(data.taxYear).toObligationsTaxYear
+
+    RetrieveCrystallisationObligationsRequest(Nino(data.nino), obligationsTaxYear)
+  }
+}

--- a/app/v2/controllers/requestParsers/validators/RetrieveCrystallisationObligationsValidator.scala
+++ b/app/v2/controllers/requestParsers/validators/RetrieveCrystallisationObligationsValidator.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.controllers.requestParsers.validators
+
+import api.controllers.requestParsers.validators.Validator
+import api.controllers.requestParsers.validators.validations._
+import api.models.errors.{MtdError, RuleTaxYearNotSupportedError}
+import v2.models.request.retrieveCrystallisationObligations.RetrieveCrystallisationObligationsRawData
+
+class RetrieveCrystallisationObligationsValidator extends Validator[RetrieveCrystallisationObligationsRawData] {
+
+  private val validationSet = List(parameterFormatValidation, parameterRuleValidation)
+
+  private def parameterFormatValidation: RetrieveCrystallisationObligationsRawData => List[List[MtdError]] = data => {
+    List(
+      NinoValidation.validate(data.nino),
+      data.taxYear.map(TaxYearValidation.validate).getOrElse(Nil)
+    )
+  }
+
+  private def parameterRuleValidation: RetrieveCrystallisationObligationsRawData => List[List[MtdError]] = data => {
+    List(
+      data.taxYear.map(MtdTaxYearValidation.validate(_, RuleTaxYearNotSupportedError)).getOrElse(Nil)
+    )
+  }
+
+  override def validate(data: RetrieveCrystallisationObligationsRawData): List[MtdError] = {
+    run(validationSet, data).distinct
+  }
+
+}

--- a/app/v2/models/audit/RetrieveCrystallisationObligationsAuditDetail.scala
+++ b/app/v2/models/audit/RetrieveCrystallisationObligationsAuditDetail.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.models.audit
+
+import api.models.audit.AuditResponse
+import api.models.auth.UserDetails
+import play.api.libs.json.{Json, Writes}
+
+case class RetrieveCrystallisationObligationsAuditDetail(userType: String,
+                                                         agentReferenceNumber: Option[String],
+                                                         nino: String,
+                                                         taxYear: Option[String],
+                                                         `X-CorrelationId`: String,
+                                                         response: AuditResponse)
+
+object RetrieveCrystallisationObligationsAuditDetail {
+  implicit val writes: Writes[RetrieveCrystallisationObligationsAuditDetail] = Json.writes[RetrieveCrystallisationObligationsAuditDetail]
+
+  def apply(userDetails: UserDetails,
+            nino: String,
+            taxYear: Option[String],
+            `X-CorrelationId`: String,
+            auditResponse: AuditResponse): RetrieveCrystallisationObligationsAuditDetail = {
+
+    RetrieveCrystallisationObligationsAuditDetail(
+      userType = userDetails.userType,
+      agentReferenceNumber = userDetails.agentReferenceNumber,
+      nino = nino,
+      taxYear = taxYear,
+      `X-CorrelationId` = `X-CorrelationId`,
+      response = auditResponse
+    )
+  }
+}

--- a/app/v2/models/request/ObligationsTaxYear.scala
+++ b/app/v2/models/request/ObligationsTaxYear.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package v1.models.request
+package v2.models.request
 
 import java.time.LocalDate
 

--- a/app/v2/models/request/retrieveCrystallisationObligations/RetrieveCrystallisationObligationsRawData.scala
+++ b/app/v2/models/request/retrieveCrystallisationObligations/RetrieveCrystallisationObligationsRawData.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.models.request.retrieveCrystallisationObligations
+
+import api.models.request.RawData
+
+case class RetrieveCrystallisationObligationsRawData(nino: String, taxYear: Option[String]) extends RawData

--- a/app/v2/models/request/retrieveCrystallisationObligations/RetrieveCrystallisationObligationsRequest.scala
+++ b/app/v2/models/request/retrieveCrystallisationObligations/RetrieveCrystallisationObligationsRequest.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.models.request.retrieveCrystallisationObligations
+
+import api.models.domain.Nino
+import v2.models.request.ObligationsTaxYear
+
+case class RetrieveCrystallisationObligationsRequest(nino: Nino, obligationsTaxYear: ObligationsTaxYear)

--- a/app/v2/models/response/retrieveCrystallisationObligations/RetrieveCrystallisationObligationsResponse.scala
+++ b/app/v2/models/response/retrieveCrystallisationObligations/RetrieveCrystallisationObligationsResponse.scala
@@ -14,10 +14,19 @@
  * limitations under the License.
  */
 
-package api.services
+package v2.models.response.retrieveCrystallisationObligations
 
-import api.controllers.RequestContextImplicits
-import api.support.DownstreamResponseMappingSupport
-import utils.Logging
+import api.models.domain.status.MtdStatus
+import play.api.libs.json.{Json, OWrites}
 
-trait BaseService extends RequestContextImplicits with DownstreamResponseMappingSupport with Logging
+case class RetrieveCrystallisationObligationsResponse(
+    periodStartDate: String,
+    periodEndDate: String,
+    dueDate: String,
+    status: MtdStatus,
+    receivedDate: Option[String]
+)
+
+object RetrieveCrystallisationObligationsResponse {
+  implicit val writes: OWrites[RetrieveCrystallisationObligationsResponse] = Json.writes[RetrieveCrystallisationObligationsResponse]
+}

--- a/app/v2/models/response/retrieveCrystallisationObligations/des/DesObligation.scala
+++ b/app/v2/models/response/retrieveCrystallisationObligations/des/DesObligation.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.models.response.retrieveCrystallisationObligations.des
+
+import api.models.domain.status.DesStatus
+import play.api.libs.json.{Json, Reads}
+import v2.models.response.retrieveCrystallisationObligations
+
+case class DesObligation(
+    inboundCorrespondenceFromDate: String,
+    inboundCorrespondenceToDate: String,
+    inboundCorrespondenceDueDate: String,
+    status: DesStatus,
+    inboundCorrespondenceDateReceived: Option[String]
+) {
+
+  def toMtd: retrieveCrystallisationObligations.RetrieveCrystallisationObligationsResponse = retrieveCrystallisationObligations.RetrieveCrystallisationObligationsResponse(
+    periodStartDate = inboundCorrespondenceFromDate,
+    periodEndDate = inboundCorrespondenceToDate,
+    dueDate = inboundCorrespondenceDueDate,
+    status = status.toMtd,
+    receivedDate = inboundCorrespondenceDateReceived
+  )
+}
+
+object DesObligation {
+  implicit val reads: Reads[DesObligation] = Json.reads[DesObligation]
+}

--- a/app/v2/models/response/retrieveCrystallisationObligations/des/DesRetrieveCrystallisationObligationsResponse.scala
+++ b/app/v2/models/response/retrieveCrystallisationObligations/des/DesRetrieveCrystallisationObligationsResponse.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.models.response.retrieveCrystallisationObligations.des
+
+import api.models.domain.PeriodKey
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{JsPath, Reads}
+
+case class DesRetrieveCrystallisationObligationsResponse(obligationDetails: Seq[DesObligation])
+
+object DesRetrieveCrystallisationObligationsResponse {
+
+  //bound case class to allow us to read from multiple lists of obligation details to merge together later
+  case class Detail(incomeSourceType: Option[String], obligation: Seq[DesObligation])
+
+  object Detail {
+    implicit val reads: Reads[Detail] = (
+      (JsPath \ "identification" \ "incomeSourceType").readNullable[String] and
+        (JsPath \ "obligationDetails").read[Seq[DesObligation]]
+    )(Detail.apply _)
+  }
+
+  implicit val reads: Reads[DesRetrieveCrystallisationObligationsResponse] = {
+    (JsPath \ "obligations")
+      .read[Seq[Detail]]
+      .map(_.filter(_.incomeSourceType.contains(PeriodKey.ITSA.toString)))
+      .map(det => DesRetrieveCrystallisationObligationsResponse(det.flatMap(_.obligation))) // flatten nested arrays into one array
+  }
+}

--- a/app/v2/services/BaseService.scala
+++ b/app/v2/services/BaseService.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.services
+
+import api.controllers.RequestContextImplicits
+import utils.Logging
+import v2.support.DownstreamResponseMappingSupport
+
+trait BaseService extends RequestContextImplicits with DownstreamResponseMappingSupport with Logging

--- a/app/v2/services/RetrieveCrystallisationObligationsService.scala
+++ b/app/v2/services/RetrieveCrystallisationObligationsService.scala
@@ -14,29 +14,30 @@
  * limitations under the License.
  */
 
-package v1.services
+package v2.services
 
 import api.controllers.RequestContext
 import api.models.errors._
 import api.services.ServiceOutcome
 import cats.data.EitherT
 import cats.implicits._
-import v1.connectors.RetrieveEOPSObligationsConnector
-import v1.models.request.retrieveEOPSObligations.RetrieveEOPSObligationsRequest
-import v1.models.response.retrieveEOPSObligations.RetrieveEOPSObligationsResponse
+import v2.connectors.RetrieveCrystallisationObligationsConnector
+import v2.models.request.retrieveCrystallisationObligations.RetrieveCrystallisationObligationsRequest
+import v2.models.response.retrieveCrystallisationObligations.RetrieveCrystallisationObligationsResponse
 
-import javax.inject.{ Inject, Singleton }
-import scala.concurrent.{ ExecutionContext, Future }
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class RetrieveEOPSObligationsService @Inject()(connector: RetrieveEOPSObligationsConnector) extends BaseService {
+class RetrieveCrystallisationObligationsService @Inject()(connector: RetrieveCrystallisationObligationsConnector) extends BaseService {
 
-  def retrieve(request: RetrieveEOPSObligationsRequest)(implicit ctx: RequestContext,
-                                                        ec: ExecutionContext): Future[ServiceOutcome[RetrieveEOPSObligationsResponse]] = {
+  def retrieve(request: RetrieveCrystallisationObligationsRequest)(
+      implicit ctx: RequestContext,
+      ec: ExecutionContext): Future[ServiceOutcome[RetrieveCrystallisationObligationsResponse]] = {
 
     val result = for {
-      downstreamResponseWrapper <- EitherT(connector.retrieveEOPSObligations(request)).leftMap(mapDownstreamErrors(downstreamErrorMap))
-      mtdResponseWrapper        <- EitherT.fromEither[Future](filterEOPSValues(downstreamResponseWrapper, request.typeOfBusiness, request.businessId))
+      downstreamResponseWrapper <- EitherT(connector.retrieveCrystallisationObligations(request)).leftMap(mapDownstreamErrors(downstreamErrorMap))
+      mtdResponseWrapper        <- EitherT.fromEither[Future](filterCrystallisationValues(downstreamResponseWrapper))
     } yield mtdResponseWrapper
 
     result.value
@@ -49,14 +50,13 @@ class RetrieveEOPSObligationsService @Inject()(connector: RetrieveEOPSObligation
       "INVALID_IDTYPE"      -> InternalError,
       "INVALID_STATUS"      -> InternalError,
       "INVALID_REGIME"      -> InternalError,
-      "INVALID_DATE_FROM"   -> FromDateFormatError,
-      "INVALID_DATE_TO"     -> ToDateFormatError,
-      "INVALID_DATE_RANGE"  -> RuleDateRangeInvalidError,
-      "INSOLVENT_TRADER"    -> RuleInsolventTraderError,
+      "INVALID_DATE_FROM"   -> InternalError,
+      "INVALID_DATE_TO"     -> InternalError,
+      "INVALID_DATE_RANGE"  -> InternalError,
       "NOT_FOUND_BPKEY"     -> NotFoundError,
+      "INSOLVENT_TRADER"    -> RuleInsolventTraderError,
       "NOT_FOUND"           -> NotFoundError,
       "SERVER_ERROR"        -> InternalError,
       "SERVICE_UNAVAILABLE" -> InternalError
     )
-
 }

--- a/app/v2/support/DownstreamResponseMappingSupport.scala
+++ b/app/v2/support/DownstreamResponseMappingSupport.scala
@@ -14,67 +14,17 @@
  * limitations under the License.
  */
 
-package api.support
+package v2.support
 
 import api.controllers.EndpointLogContext
-import api.models.domain.business.MtdBusiness
 import api.models.errors._
 import api.models.outcomes.ResponseWrapper
 import utils.Logging
-import v1.models.response.retrieveCrystallisationObligations.RetrieveCrystallisationObligationsResponse
-import v1.models.response.retrieveCrystallisationObligations.des.DesRetrieveCrystallisationObligationsResponse
-import v1.models.response.retrieveEOPSObligations.RetrieveEOPSObligationsResponse
-import v1.models.response.retrievePeriodicObligations.RetrievePeriodObligationsResponse
+import v2.models.response.retrieveCrystallisationObligations.RetrieveCrystallisationObligationsResponse
+import v2.models.response.retrieveCrystallisationObligations.des.DesRetrieveCrystallisationObligationsResponse
 
 trait DownstreamResponseMappingSupport {
   self: Logging =>
-
-  final def filterPeriodicValues(
-      responseWrapper: ResponseWrapper[RetrievePeriodObligationsResponse],
-      typeOfBusiness: Option[MtdBusiness],
-      businessId: Option[String]
-  ): Either[ErrorWrapper, ResponseWrapper[RetrievePeriodObligationsResponse]] = {
-    val filteredObligations = responseWrapper.responseData.obligations
-      .filter { obligation =>
-        typeOfBusiness.forall(_ == obligation.typeOfBusiness)
-      }
-      .filter { obligation =>
-        businessId.forall(_ == obligation.businessId)
-      }
-      .filter { obligation =>
-        obligation.obligationDetails.nonEmpty
-      }
-
-    if (filteredObligations.nonEmpty) {
-      Right(ResponseWrapper(responseWrapper.correlationId, RetrievePeriodObligationsResponse(filteredObligations)))
-    } else {
-      Left(ErrorWrapper(responseWrapper.correlationId, NoObligationsFoundError))
-    }
-  }
-
-  final def filterEOPSValues(
-      responseWrapper: ResponseWrapper[RetrieveEOPSObligationsResponse],
-      typeOfBusiness: Option[MtdBusiness],
-      businessId: Option[String]
-  ): Either[ErrorWrapper, ResponseWrapper[RetrieveEOPSObligationsResponse]] = {
-
-    val filteredObligations = responseWrapper.responseData.obligations
-      .filter { obligation =>
-        typeOfBusiness.forall(_ == obligation.typeOfBusiness)
-      }
-      .filter { obligation =>
-        businessId.forall(_ == obligation.businessId)
-      }
-      .filter { obligation =>
-        obligation.obligationDetails.nonEmpty
-      }
-
-    if (filteredObligations.nonEmpty) {
-      Right(ResponseWrapper(responseWrapper.correlationId, RetrieveEOPSObligationsResponse(filteredObligations)))
-    } else {
-      Left(ErrorWrapper(responseWrapper.correlationId, NoObligationsFoundError))
-    }
-  }
 
   final def filterCrystallisationValues(
       responseWrapper: ResponseWrapper[DesRetrieveCrystallisationObligationsResponse]

--- a/conf/v2.routes
+++ b/conf/v2.routes
@@ -1,0 +1,1 @@
+GET         /:nino/crystallisation                v2.controllers.RetrieveCrystallisationObligationsController.handleRequest(nino: String, taxYear: Option[String])

--- a/test/v1/support/DownstreamResponseMappingSupportSpec.scala
+++ b/test/v1/support/DownstreamResponseMappingSupportSpec.scala
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-package api.support
+package v1.support
 
 import api.controllers.EndpointLogContext
 import api.models.domain.business.MtdBusiness
-import api.models.domain.status.{ DesStatus, MtdStatus }
+import api.models.domain.status.{DesStatus, MtdStatus}
 import api.models.errors._
 import api.models.outcomes.ResponseWrapper
 import play.api.http.Status.BAD_REQUEST
 import support.UnitSpec
 import utils.Logging
-import v1.models.response.common.{ Obligation, ObligationDetail }
+import v1.models.response.common.{Obligation, ObligationDetail}
 import v1.models.response.retrieveCrystallisationObligations.RetrieveCrystallisationObligationsResponse
-import v1.models.response.retrieveCrystallisationObligations.des.{ DesObligation, DesRetrieveCrystallisationObligationsResponse }
+import v1.models.response.retrieveCrystallisationObligations.des.{DesObligation, DesRetrieveCrystallisationObligationsResponse}
 import v1.models.response.retrieveEOPSObligations.RetrieveEOPSObligationsResponse
 import v1.models.response.retrievePeriodicObligations.RetrievePeriodObligationsResponse
 

--- a/test/v2/connectors/RetrieveCrystallisationObligationsConnectorSpec.scala
+++ b/test/v2/connectors/RetrieveCrystallisationObligationsConnectorSpec.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.connectors
+
+import api.connectors.ConnectorSpec
+import api.models.domain.Nino
+import api.models.domain.status.DesStatus.F
+import api.models.outcomes.ResponseWrapper
+import v2.models.request.ObligationsTaxYear
+import v2.models.request.retrieveCrystallisationObligations.RetrieveCrystallisationObligationsRequest
+import v2.models.response.retrieveCrystallisationObligations.des.{DesObligation, DesRetrieveCrystallisationObligationsResponse}
+
+import scala.concurrent.Future
+
+class RetrieveCrystallisationObligationsConnectorSpec extends ConnectorSpec {
+
+  "RetrieveCrystallisationObligationsConnector" should {
+    "return the expected response for a non-TYS request" when {
+      "a valid request is made" in new DesTest with Test {
+        val outcome: Right[Nothing, ResponseWrapper[DesRetrieveCrystallisationObligationsResponse]] =
+          Right(ResponseWrapper(correlationId, response))
+
+        willGet(s"$baseUrl/enterprise/obligation-data/nino/$nino/ITSA?from=$fromDate&to=$toDate")
+          .returns(Future.successful(outcome))
+
+        await(connector.retrieveCrystallisationObligations(request)) shouldBe outcome
+      }
+    }
+  }
+
+  trait Test {
+    _: ConnectorTest =>
+
+    protected val nino     = "AA123456A"
+    protected val fromDate = "2018-04-06"
+    protected val toDate   = "2019-04-05"
+
+    val connector: RetrieveCrystallisationObligationsConnector =
+      new RetrieveCrystallisationObligationsConnector(http = mockHttpClient, appConfig = mockAppConfig)
+
+    lazy val request: RetrieveCrystallisationObligationsRequest =
+      RetrieveCrystallisationObligationsRequest(Nino(nino), ObligationsTaxYear(fromDate, toDate))
+    lazy val response: DesRetrieveCrystallisationObligationsResponse =
+      DesRetrieveCrystallisationObligationsResponse(
+        Seq(
+          DesObligation(
+            inboundCorrespondenceFromDate = fromDate,
+            inboundCorrespondenceToDate = toDate,
+            inboundCorrespondenceDueDate = toDate,
+            status = F,
+            inboundCorrespondenceDateReceived = Some(toDate)
+          )))
+  }
+}

--- a/test/v2/controllers/RetrieveCrystallisationObligationsControllerSpec.scala
+++ b/test/v2/controllers/RetrieveCrystallisationObligationsControllerSpec.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.controllers
+
+import api.controllers.{ControllerBaseSpec, ControllerTestRunner}
+import api.mocks.services.MockAuditService
+import api.models.audit.{AuditEvent, AuditResponse, GenericAuditDetail}
+import api.models.domain.Nino
+import api.models.domain.status.MtdStatus
+import api.models.errors._
+import api.models.outcomes.ResponseWrapper
+import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.Result
+import v2.mocks.requestParsers.MockRetrieveCrystallisationObligationsRequestParser
+import v2.mocks.services._
+import v2.models.request.ObligationsTaxYear
+import v2.models.request.retrieveCrystallisationObligations._
+import v2.models.response.retrieveCrystallisationObligations.RetrieveCrystallisationObligationsResponse
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class RetrieveCrystallisationObligationsControllerSpec
+    extends ControllerBaseSpec
+    with ControllerTestRunner
+    with MockRetrieveCrystallisationObligationsService
+    with MockRetrieveCrystallisationObligationsRequestParser
+    with MockAuditService {
+
+  private val taxYear = "2017-18"
+
+  private val rawData     = RetrieveCrystallisationObligationsRawData(nino, Some(taxYear))
+  private val requestData = RetrieveCrystallisationObligationsRequest(Nino(nino), ObligationsTaxYear("2017-04-06", "2018-04-05"))
+
+  private val responseBodyModel: RetrieveCrystallisationObligationsResponse =
+    RetrieveCrystallisationObligationsResponse("2018-04-06", "2019-04-05", "2020-01-31", MtdStatus.Fulfilled, Some("2020-01-25"))
+
+  private val responseJson: JsValue = Json.parse("""{
+    |  "periodStartDate": "2018-04-06",
+    |  "periodEndDate": "2019-04-05",
+    |  "dueDate": "2020-01-31",
+    |  "status": "Fulfilled",
+    |  "receivedDate": "2020-01-25"
+    |}
+    """.stripMargin)
+
+  "handleRequest" should {
+    "return a successful response with status 200 (OK)" when {
+      "given a valid request" in new Test {
+
+        MockRetrieveCrystallisationObligationsRequestParser
+          .parse(rawData)
+          .returns(Right(requestData))
+
+        MockRetrieveCrystallisationObligationsService
+          .retrieve(requestData)
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, responseBodyModel))))
+
+        runOkTestWithAudit(
+          expectedStatus = OK,
+          maybeExpectedResponseBody = Some(responseJson),
+          maybeAuditResponseBody = Some(responseJson)
+        )
+      }
+    }
+
+    "return the error as per spec" when {
+      "the parser validation fails" in new Test {
+
+        MockRetrieveCrystallisationObligationsRequestParser
+          .parse(rawData)
+          .returns(Left(ErrorWrapper(correlationId, NinoFormatError)))
+
+        runErrorTestWithAudit(NinoFormatError)
+      }
+
+      "the service returns an error" in new Test {
+
+        MockRetrieveCrystallisationObligationsRequestParser
+          .parse(rawData)
+          .returns(Right(requestData))
+
+        MockRetrieveCrystallisationObligationsService
+          .retrieve(requestData)
+          .returns(Future.successful(Left(ErrorWrapper(correlationId, RuleTaxYearNotSupportedError))))
+
+        runErrorTestWithAudit(RuleTaxYearNotSupportedError)
+      }
+    }
+  }
+
+  trait Test extends ControllerTest with AuditEventChecking {
+
+    val controller: RetrieveCrystallisationObligationsController = new RetrieveCrystallisationObligationsController(
+      authService = mockEnrolmentsAuthService,
+      lookupService = mockMtdIdLookupService,
+      parser = mockRetrieveCrystallisationObligationsRequestParser,
+      service = mockRetrieveCrystallisationObligationsService,
+      auditService = mockAuditService,
+      cc = cc,
+      idGenerator = mockIdGenerator
+    )
+
+    protected def callController(): Future[Result] = controller.handleRequest(nino, Some(taxYear))(fakeGetRequest)
+
+    def event(auditResponse: AuditResponse, requestBody: Option[JsValue]): AuditEvent[GenericAuditDetail] =
+      AuditEvent(
+        auditType = "RetrieveCrystallisationObligations",
+        transactionName = "retrieve-crystallisation-obligations",
+        detail = GenericAuditDetail(
+          userType = "Individual",
+          agentReferenceNumber = None,
+          pathParams = Map("nino" -> nino),
+          queryParams = None,
+          requestBody = requestBody,
+          `X-CorrelationId` = correlationId,
+          auditResponse = auditResponse
+        )
+      )
+
+  }
+}

--- a/test/v2/controllers/requestParsers/RetrieveCrystallisationObligationsRequestParserSpec.scala
+++ b/test/v2/controllers/requestParsers/RetrieveCrystallisationObligationsRequestParserSpec.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.controllers.requestParsers
+
+import api.models.domain.Nino
+import api.models.errors.{BadRequestError, ErrorWrapper, NinoFormatError, TaxYearFormatError}
+import support.UnitSpec
+import v2.mocks.validators.MockRetrieveCrystallisationObligationsValidator
+import v2.models.request.retrieveCrystallisationObligations.{RetrieveCrystallisationObligationsRawData, RetrieveCrystallisationObligationsRequest}
+import v2.models.request.{ObligationsTaxYear, ObligationsTaxYearHelpers}
+
+import java.time.LocalDate
+
+class RetrieveCrystallisationObligationsRequestParserSpec extends UnitSpec {
+  val nino                      = "AA123456B"
+  val overriddenDate: LocalDate = LocalDate.parse("2019-04-06")
+
+  implicit val correlationId: String = "a1e8057e-fbbc-47a8-a8b4-78d9f015c253"
+
+  val inputData: RetrieveCrystallisationObligationsRawData =
+    RetrieveCrystallisationObligationsRawData(nino, Some("2018-19"))
+
+  trait Test extends MockRetrieveCrystallisationObligationsValidator {
+    val testDate: LocalDate
+    lazy val parser: RetrieveCrystallisationObligationsRequestParser with ObligationsTaxYearHelpers =
+      new RetrieveCrystallisationObligationsRequestParser(mockValidator) with ObligationsTaxYearHelpers {
+        override val date: LocalDate = testDate
+      }
+  }
+
+  "parse" should {
+    "return a request object" when {
+      "valid request data is supplied" in new Test {
+        override val testDate: LocalDate = overriddenDate
+
+        MockRetrieveCrystallisationObligationsValidator.validate(inputData).returns(Nil)
+
+        parser.parseRequest(inputData) shouldBe
+          Right(RetrieveCrystallisationObligationsRequest(Nino(nino), ObligationsTaxYear("2018-04-06", "2019-04-05")))
+      }
+      "valid request data is supplied with no taxYear" in new Test {
+        override val testDate: LocalDate = overriddenDate
+
+        MockRetrieveCrystallisationObligationsValidator.validate(inputData.copy(taxYear = None)).returns(Nil)
+
+        parser.parseRequest(inputData.copy(taxYear = None)) shouldBe
+          Right(RetrieveCrystallisationObligationsRequest(Nino(nino), ObligationsTaxYear("2018-04-06", "2019-04-05")))
+      }
+    }
+
+    "return an ErrorWrapper" when {
+
+      "a single validation error occurs" in new Test {
+        override val testDate: LocalDate = overriddenDate
+
+        MockRetrieveCrystallisationObligationsValidator
+          .validate(inputData)
+          .returns(List(NinoFormatError))
+
+        parser.parseRequest(inputData) shouldBe
+          Left(ErrorWrapper(correlationId, NinoFormatError, None))
+      }
+
+      "multiple validation errors occur" in new Test {
+        override val testDate: LocalDate = overriddenDate
+
+        MockRetrieveCrystallisationObligationsValidator
+          .validate(inputData)
+          .returns(List(NinoFormatError, TaxYearFormatError))
+
+        parser.parseRequest(inputData) shouldBe
+          Left(ErrorWrapper(correlationId, BadRequestError, Some(Seq(NinoFormatError, TaxYearFormatError))))
+      }
+    }
+  }
+}

--- a/test/v2/controllers/requestParsers/validators/RetrieveCrystallisationObligationsValidatorSpec.scala
+++ b/test/v2/controllers/requestParsers/validators/RetrieveCrystallisationObligationsValidatorSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.controllers.requestParsers.validators
+
+import api.models.errors._
+import support.UnitSpec
+import v2.models.request.retrieveCrystallisationObligations.RetrieveCrystallisationObligationsRawData
+
+class RetrieveCrystallisationObligationsValidatorSpec extends UnitSpec {
+
+  private val validNino    = "AA123456A"
+  private val validTaxYear = "2018-19"
+
+  val validator = new RetrieveCrystallisationObligationsValidator()
+
+  "running a validation" should {
+    "return no errors" when {
+      "a valid request is supplied" in {
+        validator.validate(RetrieveCrystallisationObligationsRawData(validNino, Some(validTaxYear))) shouldBe Nil
+      }
+      "a valid request is supplied with no taxYear" in {
+        validator.validate(RetrieveCrystallisationObligationsRawData(validNino, None)) shouldBe Nil
+      }
+      "a valid request is supplied with the earliest possible taxYear" in {
+        validator.validate(RetrieveCrystallisationObligationsRawData(validNino, Some("2017-18"))) shouldBe Nil
+      }
+    }
+
+    def test(nino: String, taxYear: String, error: MtdError): Unit = {
+      s"return ${error.code} error" when {
+        s"RetrieveCrystallisationObligationsRawData($nino, $taxYear) is supplied" in {
+          validator.validate(RetrieveCrystallisationObligationsRawData(nino, Some(taxYear))) shouldBe List(error)
+        }
+      }
+    }
+
+    Seq(
+      ("A12344A", validTaxYear, NinoFormatError),
+      (validNino, "201-20", TaxYearFormatError),
+      (validNino, "2016-17", RuleTaxYearNotSupportedError),
+      (validNino, "2018-20", RuleTaxYearRangeExceededError),
+    ).foreach(args => (test _).tupled(args))
+
+    "return multiple errors" when {
+      "request supplied has multiple errors" in {
+        validator.validate(RetrieveCrystallisationObligationsRawData("A12344A", Some("20178"))) shouldBe
+          List(NinoFormatError, TaxYearFormatError)
+      }
+    }
+  }
+}

--- a/test/v2/mocks/connectors/MockRetrieveCrystallisationObligationsConnector.scala
+++ b/test/v2/mocks/connectors/MockRetrieveCrystallisationObligationsConnector.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.mocks.connectors
+
+import api.connectors.DownstreamOutcome
+import org.scalamock.handlers.CallHandler
+import org.scalamock.scalatest.MockFactory
+import uk.gov.hmrc.http.HeaderCarrier
+import v2.connectors.RetrieveCrystallisationObligationsConnector
+import v2.models.request.retrieveCrystallisationObligations.RetrieveCrystallisationObligationsRequest
+import v2.models.response.retrieveCrystallisationObligations.des.DesRetrieveCrystallisationObligationsResponse
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockRetrieveCrystallisationObligationsConnector extends MockFactory {
+  val mockRetrieveCrystallisationObligationsConnector: RetrieveCrystallisationObligationsConnector = mock[RetrieveCrystallisationObligationsConnector]
+
+  object MockRetrieveCrystallisationObligationsConnector {
+
+    def retrieve(requestData: RetrieveCrystallisationObligationsRequest)
+      : CallHandler[Future[DownstreamOutcome[DesRetrieveCrystallisationObligationsResponse]]] = {
+      (
+        mockRetrieveCrystallisationObligationsConnector
+          .retrieveCrystallisationObligations(_: RetrieveCrystallisationObligationsRequest)(
+            _: HeaderCarrier,
+            _: ExecutionContext,
+            _: String
+          )
+        )
+        .expects(requestData, *, *, *)
+    }
+  }
+}

--- a/test/v2/mocks/requestParsers/MockRetrieveCrystallisationObligationsRequestParser.scala
+++ b/test/v2/mocks/requestParsers/MockRetrieveCrystallisationObligationsRequestParser.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.mocks.requestParsers
+
+import api.models.errors.ErrorWrapper
+import org.scalamock.handlers.CallHandler
+import org.scalamock.scalatest.MockFactory
+import v2.controllers.requestParsers.RetrieveCrystallisationObligationsRequestParser
+import v2.models.request.retrieveCrystallisationObligations.{RetrieveCrystallisationObligationsRawData, RetrieveCrystallisationObligationsRequest}
+
+trait MockRetrieveCrystallisationObligationsRequestParser extends MockFactory {
+
+  val mockRetrieveCrystallisationObligationsRequestParser: RetrieveCrystallisationObligationsRequestParser =
+    mock[RetrieveCrystallisationObligationsRequestParser]
+
+  object MockRetrieveCrystallisationObligationsRequestParser {
+
+    def parse(data: RetrieveCrystallisationObligationsRawData): CallHandler[Either[ErrorWrapper, RetrieveCrystallisationObligationsRequest]] = {
+      (mockRetrieveCrystallisationObligationsRequestParser.parseRequest(_: RetrieveCrystallisationObligationsRawData)(_: String)).expects(data, *)
+    }
+  }
+
+}

--- a/test/v2/mocks/services/MockRetrieveCrystallisationObligationsService.scala
+++ b/test/v2/mocks/services/MockRetrieveCrystallisationObligationsService.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.mocks.services
+
+import api.controllers.RequestContext
+import api.models.errors.ErrorWrapper
+import api.models.outcomes.ResponseWrapper
+import org.scalamock.handlers.CallHandler
+import org.scalamock.scalatest.MockFactory
+import v2.models.request.retrieveCrystallisationObligations.RetrieveCrystallisationObligationsRequest
+import v2.models.response.retrieveCrystallisationObligations.RetrieveCrystallisationObligationsResponse
+import v2.services.RetrieveCrystallisationObligationsService
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockRetrieveCrystallisationObligationsService extends MockFactory {
+
+  val mockRetrieveCrystallisationObligationsService: RetrieveCrystallisationObligationsService = mock[RetrieveCrystallisationObligationsService]
+
+  object MockRetrieveCrystallisationObligationsService {
+
+    def retrieve(requestData: RetrieveCrystallisationObligationsRequest)
+      : CallHandler[Future[Either[ErrorWrapper, ResponseWrapper[RetrieveCrystallisationObligationsResponse]]]] = {
+      (mockRetrieveCrystallisationObligationsService
+        .retrieve(_: RetrieveCrystallisationObligationsRequest)(_: RequestContext, _: ExecutionContext))
+        .expects(requestData, *, *)
+    }
+  }
+
+}

--- a/test/v2/mocks/validators/MockRetrieveCrystallisationObligationsValidator.scala
+++ b/test/v2/mocks/validators/MockRetrieveCrystallisationObligationsValidator.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.mocks.validators
+
+import api.models.errors.MtdError
+import org.scalamock.handlers.CallHandler1
+import org.scalamock.scalatest.MockFactory
+import v2.controllers.requestParsers.validators.RetrieveCrystallisationObligationsValidator
+import v2.models.request.retrieveCrystallisationObligations.RetrieveCrystallisationObligationsRawData
+
+class MockRetrieveCrystallisationObligationsValidator extends MockFactory {
+
+  val mockValidator: RetrieveCrystallisationObligationsValidator = mock[RetrieveCrystallisationObligationsValidator]
+
+  object MockRetrieveCrystallisationObligationsValidator {
+
+    def validate(data: RetrieveCrystallisationObligationsRawData): CallHandler1[RetrieveCrystallisationObligationsRawData, List[MtdError]] = {
+      (mockValidator
+        .validate(_: RetrieveCrystallisationObligationsRawData))
+        .expects(data)
+    }
+  }
+}

--- a/test/v2/models/audit/RetrieveCrystallisationObligationsAuditDetailSpec.scala
+++ b/test/v2/models/audit/RetrieveCrystallisationObligationsAuditDetailSpec.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.models.audit
+
+import api.models.audit.AuditResponse
+import api.models.auth.UserDetails
+import play.api.libs.json.Json
+import support.UnitSpec
+
+class RetrieveCrystallisationObligationsAuditDetailSpec extends UnitSpec {
+
+  val nino        = "ZG903729C"
+  val invalidNino = "notANino"
+  val businessId  = "XAIS123456789012"
+
+  val validJson = Json.parse(s"""{
+       |    "userType": "Agent",
+       |    "agentReferenceNumber":"012345678",
+       |    "nino": "$nino",
+       |    "taxYear": "2019-20",
+       |    "X-CorrelationId": "a1e8057e-fbbc-47a8-a8b478d9f015c253",
+       |    "response": {
+       |      "httpStatus": 200,
+       |      "body": {
+       |    "status": "Fulfilled",
+       |    "periodStartDate": "2018-04-06",
+       |    "periodEndDate": "2019-04-05",
+       |    "receivedDate": "2020-01-25",
+       |    "dueDate": "1920-01-31"
+       |    }
+       |  }
+       |}""".stripMargin)
+
+  val validBody = RetrieveCrystallisationObligationsAuditDetail(
+    userDetails = UserDetails("id", "Agent", Some("012345678")),
+    nino = nino,
+    taxYear = Some("2019-20"),
+    `X-CorrelationId` = "a1e8057e-fbbc-47a8-a8b478d9f015c253",
+    auditResponse = AuditResponse(
+      200,
+      Right(Some(Json.parse("""
+          |     {
+          |    "status": "Fulfilled",
+          |    "periodStartDate": "2018-04-06",
+          |    "periodEndDate": "2019-04-05",
+          |    "receivedDate": "2020-01-25",
+          |    "dueDate": "1920-01-31"
+          |    }
+          |""".stripMargin)))
+    )
+  )
+
+  "writes" must {
+    "work" when {
+      "success response" in {
+        Json.toJson(validBody) shouldBe validJson
+      }
+    }
+  }
+}

--- a/test/v2/models/request/ObligationsTaxYearSpec.scala
+++ b/test/v2/models/request/ObligationsTaxYearSpec.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.models.request
+
+import support.UnitSpec
+
+import java.time.LocalDate
+
+class ObligationsTaxYearSpec extends UnitSpec {
+
+  trait Test extends ObligationsTaxYearHelpers
+
+  "RawTaxYear" should {
+    "return a RawTaxYear model" when {
+      "passed a valid taxYear" in new Test {
+        RawTaxYear(Some("2019-20")) shouldBe RawTaxYear(Some("2019-20"))
+      }
+      "passed no taxYear" in new Test {
+        RawTaxYear(None) shouldBe RawTaxYear(None)
+      }
+    }
+    "return an exception" when {
+      "passed an invalid taxYear" in new Test {
+        val result = intercept[IllegalArgumentException](RawTaxYear(Some("201-20")))
+        result.getMessage shouldBe "requirement failed"
+      }
+    }
+  }
+
+  "RawTaxYear.toObligationsTaxYear" should {
+    "return an ObligationsTaxYear" when {
+      "a valid taxYear is entered" in new Test {
+        RawTaxYear(Some("2019-20")).toObligationsTaxYear shouldBe ObligationsTaxYear("2019-04-06", "2020-04-05")
+      }
+      "no taxYear is entered" in new Test {
+        override val date: LocalDate = LocalDate.parse("2020-04-06")
+        RawTaxYear(None).toObligationsTaxYear shouldBe ObligationsTaxYear("2019-04-06", "2020-04-05")
+      }
+    }
+    "return an exception" when {
+      "passed an invalid taxYear" in new Test {
+        val result = intercept[IllegalArgumentException](RawTaxYear(Some("201-20")).toObligationsTaxYear)
+        result.getMessage shouldBe "requirement failed"
+      }
+    }
+  }
+
+  "mostRecentTaxYear" should {
+    "return fromMtd(2018-19)" when {
+      "passed a date in the tax year 2019-20 before 04-05" in new Test {
+        override val date: LocalDate = LocalDate.parse("2020-02-06")
+        getMostRecentTaxYear shouldBe "2018-19"
+      }
+      "passed the last date in 2019-20 (2020-04-05)" in new Test {
+        override val date: LocalDate = LocalDate.parse("2020-04-05")
+        getMostRecentTaxYear shouldBe "2018-19"
+      }
+    }
+
+    "return fromMtd(2019-20)" when {
+      "passed a date after 2020-04-05" in new Test {
+        override val date: LocalDate = LocalDate.parse("2020-04-06")
+        getMostRecentTaxYear shouldBe  "2019-20"
+      }
+    }
+  }
+}

--- a/test/v2/models/response/retrieveCrystallisationObligations/RetrieveCrystallisationObligationsResponseSpec.scala
+++ b/test/v2/models/response/retrieveCrystallisationObligations/RetrieveCrystallisationObligationsResponseSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.models.response.retrieveCrystallisationObligations
+
+import api.models.domain.status.MtdStatus
+import play.api.libs.json.Json
+import support.UnitSpec
+
+class RetrieveCrystallisationObligationsResponseSpec extends UnitSpec {
+  "writes" should {
+    "write to JSON" when {
+      "passed a model with status Fulfilled" in {
+        val json  = Json.parse("""
+            |{
+            |    "status": "Fulfilled",
+            |    "periodStartDate": "2018-04-06",
+            |    "periodEndDate": "2019-04-05",
+            |    "receivedDate": "2020-01-25",
+            |    "dueDate": "1920-01-31"
+            |}
+            |""".stripMargin)
+        val model = RetrieveCrystallisationObligationsResponse("2018-04-06", "2019-04-05", "1920-01-31", MtdStatus.Fulfilled, Some("2020-01-25"))
+
+        Json.toJson(model) shouldBe json
+      }
+      "passed a model with status Open" in {
+        val json  = Json.parse("""
+            |{
+            |    "status": "Open",
+            |    "periodStartDate": "2018-04-06",
+            |    "periodEndDate": "2019-04-05",
+            |    "receivedDate": "2020-01-25",
+            |    "dueDate": "1920-01-31"
+            |}
+            |""".stripMargin)
+        val model = RetrieveCrystallisationObligationsResponse("2018-04-06", "2019-04-05", "1920-01-31", MtdStatus.Open, Some("2020-01-25"))
+
+        Json.toJson(model) shouldBe json
+      }
+      "passed a model with no receivedDate" in {
+        val json  = Json.parse("""
+            |{
+            |    "status": "Open",
+            |    "periodStartDate": "2018-04-06",
+            |    "periodEndDate": "2019-04-05",
+            |    "dueDate": "1920-01-31"
+            |}
+            |""".stripMargin)
+        val model = RetrieveCrystallisationObligationsResponse("2018-04-06", "2019-04-05", "1920-01-31", MtdStatus.Open, None)
+
+        Json.toJson(model) shouldBe json
+      }
+    }
+  }
+}

--- a/test/v2/models/response/retrieveCrystallisationObligations/des/DesObligationSpec.scala
+++ b/test/v2/models/response/retrieveCrystallisationObligations/des/DesObligationSpec.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.models.response.retrieveCrystallisationObligations.des
+
+import api.models.domain.status.{DesStatus, MtdStatus}
+import play.api.libs.json.Json
+import support.UnitSpec
+import v2.models.response.retrieveCrystallisationObligations.RetrieveCrystallisationObligationsResponse
+
+class DesObligationSpec extends UnitSpec {
+  "reads" should {
+    "read to a model" when {
+      "passed JSON with status F" in {
+        val json  = Json.parse("""
+            |{
+            |    "status": "F",
+            |    "inboundCorrespondenceFromDate": "2018-04-06",
+            |    "inboundCorrespondenceToDate": "2019-04-05",
+            |    "inboundCorrespondenceDateReceived": "2020-01-25",
+            |    "inboundCorrespondenceDueDate": "1920-01-31",
+            |    "periodKey": "ITSA"
+            |}
+            |""".stripMargin)
+        val model = DesObligation("2018-04-06", "2019-04-05", "1920-01-31", DesStatus.F, Some("2020-01-25"))
+
+        json.as[DesObligation] shouldBe model
+      }
+      "passed JSON with status O" in {
+        val json  = Json.parse("""
+            |{
+            |    "status": "O",
+            |    "inboundCorrespondenceFromDate": "2018-04-06",
+            |    "inboundCorrespondenceToDate": "2019-04-05",
+            |    "inboundCorrespondenceDateReceived": "2020-01-25",
+            |    "inboundCorrespondenceDueDate": "1920-01-31",
+            |    "periodKey": "ITSA"
+            |}
+            |""".stripMargin)
+        val model = DesObligation("2018-04-06", "2019-04-05", "1920-01-31", DesStatus.O, Some("2020-01-25"))
+
+        json.as[DesObligation] shouldBe model
+      }
+      "passed JSON with no inboundCorrespondenceDateReceived" in {
+        val json  = Json.parse("""
+            |{
+            |    "status": "O",
+            |    "inboundCorrespondenceFromDate": "2018-04-06",
+            |    "inboundCorrespondenceToDate": "2019-04-05",
+            |    "inboundCorrespondenceDueDate": "1920-01-31",
+            |    "periodKey": "ITSA"
+            |}
+            |""".stripMargin)
+        val model = DesObligation("2018-04-06", "2019-04-05", "1920-01-31", DesStatus.O, None)
+
+        json.as[DesObligation] shouldBe model
+      }
+    }
+  }
+  "toMtd" should {
+    "return a RetrieveCrystallisationObligationsResponse model" when {
+      "passed a valid model" in {
+        val model = DesObligation("2018-04-06", "2019-04-05", "1920-01-31", DesStatus.O, None)
+
+        model.toMtd shouldBe RetrieveCrystallisationObligationsResponse("2018-04-06", "2019-04-05", "1920-01-31", MtdStatus.Open, None)
+      }
+    }
+  }
+}

--- a/test/v2/models/response/retrieveCrystallisationObligations/des/DesRetrieveCrystallisationObligationsResponseSpec.scala
+++ b/test/v2/models/response/retrieveCrystallisationObligations/des/DesRetrieveCrystallisationObligationsResponseSpec.scala
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.models.response.retrieveCrystallisationObligations.des
+
+import api.models.domain.status.DesStatus
+import play.api.libs.json.Json
+import support.UnitSpec
+
+class DesRetrieveCrystallisationObligationsResponseSpec extends UnitSpec {
+  "reads" should {
+    "parse to a model" when {
+      "passed obligations with a single item in the obligationDetails array and a single item in the obligations array" in {
+        val desJson = Json.parse("""
+            |{
+            |    "obligations": [
+            |        {
+            |            "identification": {
+            |                "incomeSourceType": "ITSA",
+            |                "referenceNumber": "AB123456A",
+            |                "referenceType": "NINO"
+            |            },
+            |            "obligationDetails": [
+            |                {
+            |                    "status": "F",
+            |                    "inboundCorrespondenceFromDate": "2018-04-06",
+            |                    "inboundCorrespondenceToDate": "2019-04-05",
+            |                    "inboundCorrespondenceDateReceived": "2020-01-25",
+            |                    "inboundCorrespondenceDueDate": "1920-01-31",
+            |                    "periodKey": "#001"
+            |                }
+            |            ]
+            |        }
+            |    ]
+            |}
+            |""".stripMargin)
+        desJson.as[DesRetrieveCrystallisationObligationsResponse] shouldBe DesRetrieveCrystallisationObligationsResponse(
+          Seq(
+            DesObligation("2018-04-06", "2019-04-05", "1920-01-31", status = DesStatus.F, Some("2020-01-25"))
+          ))
+      }
+      "passed obligations with multiple items in the obligationDetails array and a single item in the obligations array" in {
+        val desJson = Json.parse("""
+            |{
+            |    "obligations": [
+            |        {
+            |            "identification": {
+            |                "incomeSourceType": "ITSA",
+            |                "referenceNumber": "AB123456A",
+            |                "referenceType": "NINO"
+            |            },
+            |            "obligationDetails": [
+            |                {
+            |                    "status": "F",
+            |                    "inboundCorrespondenceFromDate": "2018-04-06",
+            |                    "inboundCorrespondenceToDate": "2019-04-05",
+            |                    "inboundCorrespondenceDateReceived": "2020-01-25",
+            |                    "inboundCorrespondenceDueDate": "1920-01-31",
+            |                    "periodKey": "#001"
+            |                },
+            |                {
+            |                    "status": "O",
+            |                    "inboundCorrespondenceFromDate": "2017-04-06",
+            |                    "inboundCorrespondenceToDate": "2019-04-05",
+            |                    "inboundCorrespondenceDateReceived": "2020-01-25",
+            |                    "inboundCorrespondenceDueDate": "1920-01-31",
+            |                    "periodKey": "#001"
+            |                }
+            |            ]
+            |        }
+            |    ]
+            |}
+            |""".stripMargin)
+        desJson.as[DesRetrieveCrystallisationObligationsResponse] shouldBe DesRetrieveCrystallisationObligationsResponse(
+          Seq(
+            DesObligation("2018-04-06", "2019-04-05", "1920-01-31", status = DesStatus.F, Some("2020-01-25")),
+            DesObligation("2017-04-06", "2019-04-05", "1920-01-31", status = DesStatus.O, Some("2020-01-25"))
+          ))
+      }
+      "passed obligations with a single item in the obligationDetails array and multiple items in the obligations array" in {
+        val desJson = Json.parse("""
+            |{
+            |    "obligations": [
+            |        {
+            |            "identification": {
+            |                "incomeSourceType": "ITSA",
+            |                "referenceNumber": "AB123456A",
+            |                "referenceType": "NINO"
+            |            },
+            |            "obligationDetails": [
+            |                {
+            |                    "status": "F",
+            |                    "inboundCorrespondenceFromDate": "2018-04-06",
+            |                    "inboundCorrespondenceToDate": "2019-04-05",
+            |                    "inboundCorrespondenceDateReceived": "2020-01-25",
+            |                    "inboundCorrespondenceDueDate": "1920-01-31",
+            |                    "periodKey": "#001"
+            |                }
+            |            ]
+            |        },
+            |        {
+            |            "identification": {
+            |                "incomeSourceType": "ITSA",
+            |                "referenceNumber": "AB123456A",
+            |                "referenceType": "NINO"
+            |            },
+            |            "obligationDetails": [
+            |                {
+            |                    "status": "O",
+            |                    "inboundCorrespondenceFromDate": "2018-04-06",
+            |                    "inboundCorrespondenceToDate": "2019-04-05",
+            |                    "inboundCorrespondenceDateReceived": "2020-01-25",
+            |                    "inboundCorrespondenceDueDate": "1921-01-31",
+            |                    "periodKey": "#001"
+            |                }
+            |            ]
+            |        }
+            |    ]
+            |}
+            |""".stripMargin)
+        desJson.as[DesRetrieveCrystallisationObligationsResponse] shouldBe DesRetrieveCrystallisationObligationsResponse(
+          Seq(
+            DesObligation("2018-04-06", "2019-04-05", "1920-01-31", status = DesStatus.F, Some("2020-01-25")),
+            DesObligation("2018-04-06", "2019-04-05", "1921-01-31", status = DesStatus.O, Some("2020-01-25"))
+          ))
+      }
+      "passed obligations with multiple items in the obligationDetails array and multiple items in the obligations arrays" in {
+        val desJson = Json.parse("""
+            |{
+            |    "obligations": [
+            |        {
+            |            "identification": {
+            |                "incomeSourceType": "ITSA",
+            |                "referenceNumber": "AB123456A",
+            |                "referenceType": "NINO"
+            |            },
+            |            "obligationDetails": [
+            |                {
+            |                    "status": "F",
+            |                    "inboundCorrespondenceFromDate": "2018-04-06",
+            |                    "inboundCorrespondenceToDate": "2019-04-05",
+            |                    "inboundCorrespondenceDateReceived": "2020-01-25",
+            |                    "inboundCorrespondenceDueDate": "1920-01-31",
+            |                    "periodKey": "#001"
+            |                },
+            |                {
+            |                    "status": "O",
+            |                    "inboundCorrespondenceFromDate": "2017-04-06",
+            |                    "inboundCorrespondenceToDate": "2019-04-05",
+            |                    "inboundCorrespondenceDateReceived": "2020-01-25",
+            |                    "inboundCorrespondenceDueDate": "1920-01-31",
+            |                    "periodKey": "#001"
+            |                }
+            |            ]
+            |        },
+            |        {
+            |            "identification": {
+            |                "incomeSourceType": "ITSA",
+            |                "referenceNumber": "AB123456A",
+            |                "referenceType": "NINO"
+            |            },
+            |            "obligationDetails": [
+            |                {
+            |                    "status": "F",
+            |                    "inboundCorrespondenceFromDate": "2018-04-06",
+            |                    "inboundCorrespondenceToDate": "2019-04-05",
+            |                    "inboundCorrespondenceDateReceived": "2020-01-25",
+            |                    "inboundCorrespondenceDueDate": "1920-01-31",
+            |                    "periodKey": "#001"
+            |                },
+            |                {
+            |                    "status": "O",
+            |                    "inboundCorrespondenceFromDate": "2017-04-06",
+            |                    "inboundCorrespondenceToDate": "2019-04-05",
+            |                    "inboundCorrespondenceDateReceived": "2020-01-25",
+            |                    "inboundCorrespondenceDueDate": "1920-01-31",
+            |                    "periodKey": "#001"
+            |                }
+            |            ]
+            |        }
+            |    ]
+            |}
+            |""".stripMargin)
+        desJson.as[DesRetrieveCrystallisationObligationsResponse] shouldBe DesRetrieveCrystallisationObligationsResponse(
+          Seq(
+            DesObligation("2018-04-06", "2019-04-05", "1920-01-31", DesStatus.F, Some("2020-01-25")),
+            DesObligation("2017-04-06", "2019-04-05", "1920-01-31", DesStatus.O, Some("2020-01-25")),
+            DesObligation("2018-04-06", "2019-04-05", "1920-01-31", DesStatus.F, Some("2020-01-25")),
+            DesObligation("2017-04-06", "2019-04-05", "1920-01-31", DesStatus.O, Some("2020-01-25"))
+          ))
+      }
+    }
+  }
+
+  it should {
+    "filter out objects without ITSA incomeSourceType" when {
+      "passed obligations with a single item in the obligationDetails array and a single item in the obligations array" in {
+        val desJson = Json.parse("""
+            |{
+            |    "obligations": [
+            |        {
+            |            "identification": {
+            |                "incomeSourceType": "OTHER INCOME SOURCE TYPE",
+            |                "referenceNumber": "AB123456A",
+            |                "referenceType": "NINO"
+            |            },
+            |            "obligationDetails": [
+            |                {
+            |                    "status": "F",
+            |                    "inboundCorrespondenceFromDate": "2018-04-06",
+            |                    "inboundCorrespondenceToDate": "2019-04-05",
+            |                    "inboundCorrespondenceDateReceived": "2020-01-25",
+            |                    "inboundCorrespondenceDueDate": "1920-01-31",
+            |                    "periodKey": "#001"
+            |                }
+            |            ]
+            |        }
+            |    ]
+            |}
+            |""".stripMargin)
+        desJson.as[DesRetrieveCrystallisationObligationsResponse] shouldBe DesRetrieveCrystallisationObligationsResponse(Seq())
+      }
+      "passed obligations with a single item in the obligationDetails array and multiple items in the obligations array" in {
+        val desJson = Json.parse("""
+            |{
+            |    "obligations": [
+            |        {
+            |            "identification": {
+            |                "incomeSourceType": "ITSA",
+            |                "referenceNumber": "AB123456A",
+            |                "referenceType": "NINO"
+            |            },
+            |            "obligationDetails": [
+            |                {
+            |                    "status": "F",
+            |                    "inboundCorrespondenceFromDate": "2018-04-06",
+            |                    "inboundCorrespondenceToDate": "2019-04-05",
+            |                    "inboundCorrespondenceDateReceived": "2020-01-25",
+            |                    "inboundCorrespondenceDueDate": "1920-01-31",
+            |                    "periodKey": "#001"
+            |                }
+            |            ]
+            |        },
+            |        {
+            |            "identification": {
+            |                "incomeSourceType": "OTHER INCOME SOURCE TYPE",
+            |                "referenceNumber": "AB123456A",
+            |                "referenceType": "NINO"
+            |            },
+            |            "obligationDetails": [
+            |                {
+            |                    "status": "O",
+            |                    "inboundCorrespondenceFromDate": "2018-04-06",
+            |                    "inboundCorrespondenceToDate": "2019-04-05",
+            |                    "inboundCorrespondenceDateReceived": "2020-01-25",
+            |                    "inboundCorrespondenceDueDate": "1921-01-31",
+            |                    "periodKey": "#001"
+            |                }
+            |            ]
+            |        }
+            |    ]
+            |}
+            |""".stripMargin)
+        desJson.as[DesRetrieveCrystallisationObligationsResponse] shouldBe DesRetrieveCrystallisationObligationsResponse(
+          Seq(
+            DesObligation("2018-04-06", "2019-04-05", "1920-01-31", DesStatus.F, Some("2020-01-25"))
+          ))
+      }
+    }
+  }
+}

--- a/test/v2/services/RetrieveCrystallisationObligationsServiceSpec.scala
+++ b/test/v2/services/RetrieveCrystallisationObligationsServiceSpec.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.services
+
+import api.controllers.EndpointLogContext
+import api.models.domain.Nino
+import api.models.domain.status.DesStatus.F
+import api.models.domain.status.MtdStatus.Fulfilled
+import api.models.errors._
+import api.models.outcomes.ResponseWrapper
+import api.services.ServiceSpec
+import uk.gov.hmrc.http.HeaderCarrier
+import v2.mocks.connectors.MockRetrieveCrystallisationObligationsConnector
+import v2.models.request.ObligationsTaxYear
+import v2.models.request.retrieveCrystallisationObligations.RetrieveCrystallisationObligationsRequest
+import v2.models.response.retrieveCrystallisationObligations.RetrieveCrystallisationObligationsResponse
+import v2.models.response.retrieveCrystallisationObligations.des.{DesObligation, DesRetrieveCrystallisationObligationsResponse}
+
+import scala.concurrent.Future
+
+class RetrieveCrystallisationObligationsServiceSpec extends ServiceSpec {
+
+  private val nino     = "AA123456A"
+  private val fromDate = "2018-04-06"
+  private val toDate   = "2019-04-05"
+
+  private val requestData = RetrieveCrystallisationObligationsRequest(Nino(nino), ObligationsTaxYear(fromDate, toDate))
+
+  val downstreamResponseModel: DesRetrieveCrystallisationObligationsResponse = DesRetrieveCrystallisationObligationsResponse(
+    Seq(
+      DesObligation("earlier", "then", "before now", F, Some("now"))
+    ))
+
+  val mtdResponseModel: RetrieveCrystallisationObligationsResponse =
+    RetrieveCrystallisationObligationsResponse("earlier", "then", "before now", Fulfilled, Some("now"))
+
+  trait Test extends MockRetrieveCrystallisationObligationsConnector {
+    implicit val hc: HeaderCarrier              = HeaderCarrier()
+    implicit val logContext: EndpointLogContext = EndpointLogContext("c", "ep")
+
+    val service = new RetrieveCrystallisationObligationsService(
+      connector = mockRetrieveCrystallisationObligationsConnector
+    )
+  }
+
+  "service" should {
+    "return a successful response" when {
+      "a successful response is pased through" in new Test {
+
+        MockRetrieveCrystallisationObligationsConnector
+          .retrieve(requestData)
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, downstreamResponseModel))))
+
+        await(service.retrieve(requestData)) shouldBe Right(ResponseWrapper(correlationId, mtdResponseModel))
+      }
+    }
+
+    "unsuccessful" must {
+      "map errors according to spec" when {
+
+        def serviceError(downstreamErrorCode: String, error: MtdError): Unit =
+          s"a $downstreamErrorCode error is returned from the service" in new Test {
+
+            MockRetrieveCrystallisationObligationsConnector
+              .retrieve(requestData)
+              .returns(Future.successful(Left(ResponseWrapper(correlationId, DownstreamErrors.single(DownstreamErrorCode(downstreamErrorCode))))))
+
+            await(service.retrieve(requestData)) shouldBe Left(ErrorWrapper(correlationId, error))
+          }
+
+        val input = List(
+          ("INVALID_IDNUMBER", NinoFormatError),
+          ("INVALID_IDTYPE", InternalError),
+          ("INVALID_STATUS", InternalError),
+          ("INVALID_REGIME", InternalError),
+          ("INVALID_DATE_FROM", InternalError),
+          ("INVALID_DATE_TO", InternalError),
+          ("INVALID_DATE_RANGE", InternalError),
+          ("NOT_FOUND_BPKEY", NotFoundError),
+          ("INSOLVENT_TRADER", RuleInsolventTraderError),
+          ("NOT_FOUND", NotFoundError),
+          ("SERVER_ERROR", InternalError),
+          ("SERVICE_UNAVAILABLE", InternalError)
+        )
+
+        input.foreach(args => (serviceError _).tupled(args))
+      }
+
+      "error when the connector returns an empty obligations list (JSON Reads filter out other obligations)" in new Test {
+        val responseModel: DesRetrieveCrystallisationObligationsResponse = DesRetrieveCrystallisationObligationsResponse(Seq())
+
+        MockRetrieveCrystallisationObligationsConnector
+          .retrieve(requestData)
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, responseModel))))
+
+        await(service.retrieve(requestData)) shouldBe Left(ErrorWrapper(correlationId, NoObligationsFoundError))
+      }
+    }
+  }
+}

--- a/test/v2/support/DownstreamResponseMappingSupportSpec.scala
+++ b/test/v2/support/DownstreamResponseMappingSupportSpec.scala
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v2.support
+
+import api.controllers.EndpointLogContext
+import api.models.domain.status.{ DesStatus, MtdStatus }
+import api.models.errors._
+import api.models.outcomes.ResponseWrapper
+import play.api.http.Status.BAD_REQUEST
+import support.UnitSpec
+import utils.Logging
+import v2.models.response.retrieveCrystallisationObligations.RetrieveCrystallisationObligationsResponse
+import v2.models.response.retrieveCrystallisationObligations.des.{ DesObligation, DesRetrieveCrystallisationObligationsResponse }
+
+class DownstreamResponseMappingSupportSpec extends UnitSpec {
+
+  implicit val logContext: EndpointLogContext                = EndpointLogContext("ctrl", "ep")
+  val mapping: DownstreamResponseMappingSupport with Logging = new DownstreamResponseMappingSupport with Logging {}
+
+  val correlationId = "someCorrelationId"
+
+  object Error1 extends MtdError("msg", "code1", BAD_REQUEST)
+
+  object Error2 extends MtdError("msg", "code2", BAD_REQUEST)
+
+  object ErrorBvrMain extends MtdError("msg", "bvrMain", BAD_REQUEST)
+
+  object ErrorBvr extends MtdError("msg", "bvr", BAD_REQUEST)
+
+  val errorCodeMap: PartialFunction[String, MtdError] = {
+    case "ERR1" => Error1
+    case "ERR2" => Error2
+    case "DS"   => InternalError
+  }
+
+  "mapping Downstream errors" when {
+    "single error" when {
+      "the error code is in the map provided" must {
+        "use the mapping and wrap" in {
+          mapping.mapDownstreamErrors(errorCodeMap)(ResponseWrapper(correlationId, DownstreamErrors.single(DownstreamErrorCode("ERR1")))) shouldBe
+            ErrorWrapper(correlationId, Error1)
+        }
+      }
+
+      "the error code is not in the map provided" must {
+        "default to DownstreamError and wrap" in {
+          mapping.mapDownstreamErrors(errorCodeMap)(ResponseWrapper(correlationId, DownstreamErrors.single(DownstreamErrorCode("UNKNOWN")))) shouldBe
+            ErrorWrapper(correlationId, InternalError)
+        }
+      }
+    }
+
+    "multiple errors" when {
+      "the error codes is in the map provided" must {
+        "use the mapping and wrap with main error type of BadRequest" in {
+          mapping.mapDownstreamErrors(errorCodeMap)(
+            ResponseWrapper(correlationId, DownstreamErrors(List(DownstreamErrorCode("ERR1"), DownstreamErrorCode("ERR2"))))) shouldBe
+            ErrorWrapper(correlationId, BadRequestError, Some(Seq(Error1, Error2)))
+        }
+      }
+
+      "the error code is not in the map provided" must {
+        "default main error to DownstreamError ignore other errors" in {
+          mapping.mapDownstreamErrors(errorCodeMap)(
+            ResponseWrapper(correlationId, DownstreamErrors(List(DownstreamErrorCode("ERR1"), DownstreamErrorCode("UNKNOWN"))))) shouldBe
+            ErrorWrapper(correlationId, InternalError)
+        }
+      }
+
+      "one of the mapped errors is DownstreamError" must {
+        "wrap the errors with main error type of DownstreamError" in {
+          mapping.mapDownstreamErrors(errorCodeMap)(
+            ResponseWrapper(correlationId, DownstreamErrors(List(DownstreamErrorCode("ERR1"), DownstreamErrorCode("DS"))))) shouldBe
+            ErrorWrapper(correlationId, InternalError)
+        }
+      }
+    }
+
+    "the error code is an OutboundError" must {
+      "return the error as is (in an ErrorWrapper)" in {
+        mapping.mapDownstreamErrors(errorCodeMap)(ResponseWrapper(correlationId, OutboundError(ErrorBvrMain))) shouldBe
+          ErrorWrapper(correlationId, ErrorBvrMain)
+      }
+    }
+
+    "the error code is an OutboundError with multiple errors" must {
+      "return the error as is (in an ErrorWrapper)" in {
+        mapping.mapDownstreamErrors(errorCodeMap)(ResponseWrapper(correlationId, OutboundError(ErrorBvrMain, Some(Seq(ErrorBvr))))) shouldBe
+          ErrorWrapper(correlationId, ErrorBvrMain, Some(Seq(ErrorBvr)))
+      }
+    }
+  }
+
+  "filterCrystallisationValues" when {
+    "passed a valid DES model" should {
+      "return an MTD model" in {
+        val desModel = DesRetrieveCrystallisationObligationsResponse(
+          Seq(
+            DesObligation("", "", "", DesStatus.F, None)
+          ))
+        val mtdModel = RetrieveCrystallisationObligationsResponse(
+          "",
+          "",
+          "",
+          MtdStatus.Fulfilled,
+          None
+        )
+        mapping.filterCrystallisationValues(ResponseWrapper(correlationId, desModel)) shouldBe Right(ResponseWrapper(correlationId, mtdModel))
+      }
+    }
+    "passed a DES model with nothing in the array" should {
+      "return a NO_OBLIGATIONS_FOUND error" in {
+        val desModel = DesRetrieveCrystallisationObligationsResponse(Seq())
+        mapping.filterCrystallisationValues(ResponseWrapper(correlationId, desModel)) shouldBe Left(
+          ErrorWrapper(correlationId, NoObligationsFoundError))
+      }
+    }
+    "passed a DES model with more than one object in the array" should {
+      "return an INTERNAL_SERVER_ERROR error" in {
+        val desModel = DesRetrieveCrystallisationObligationsResponse(
+          Seq(
+            DesObligation("", "", "", DesStatus.F, None),
+            DesObligation("", "", "", DesStatus.O, None)
+          ))
+        mapping.filterCrystallisationValues(ResponseWrapper(correlationId, desModel)) shouldBe Left(ErrorWrapper(correlationId, InternalError))
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This creates a copy of the Retrieve Crystallisation Obligations endpoint in the V2 folder, in preparation for V2 changes. This only copies the code, it doesn't not include any behavioural changes itself. There were two files in the base `api` folder which has v1 specific code, so I had to move these into the `v1` folder, and create copies in the `v2` folder.