### PR TITLE
MTDSA-16695 - error handling for obligations

### DIFF
--- a/app/api/models/errors/CommonMtdErrors.scala
+++ b/app/api/models/errors/CommonMtdErrors.scala
@@ -72,3 +72,6 @@ object UnsupportedVersionError  extends MtdError(code = "NOT_FOUND", message = "
 
 object InvalidBodyTypeError
     extends MtdError(code = "INVALID_BODY_TYPE", message = "Expecting text/json or application/json body", UNSUPPORTED_MEDIA_TYPE)
+
+//Stub errors
+object RuleIncorrectGovTestScenarioError extends MtdError("RULE_INCORRECT_GOV_TEST_SCENARIO", "The Gov-Test-Scenario was not found", BAD_REQUEST)

--- a/app/v1/support/DownstreamResponseMappingSupport.scala
+++ b/app/v1/support/DownstreamResponseMappingSupport.scala
@@ -90,9 +90,15 @@ trait DownstreamResponseMappingSupport {
   final def mapDownstreamErrors[A](errorCodeMap: PartialFunction[String, MtdError])(downstreamResponseWrapper: ResponseWrapper[DownstreamError])(
       implicit logContext: EndpointLogContext): ErrorWrapper = {
 
-    lazy val defaultErrorCodeMapping: String => MtdError = { code =>
-      logger.warn(s"[${logContext.controllerName}] [${logContext.endpointName}] - No mapping found for error code $code")
-      InternalError
+    lazy val defaultErrorCodeMapping: String => MtdError = {
+      case "UNMATCHED_STUB_ERROR" => {
+        logger.warn(s"[${logContext.controllerName}] [${logContext.endpointName}] - No matching stub was found")
+        RuleIncorrectGovTestScenarioError
+      }
+      case code => {
+        logger.warn(s"[${logContext.controllerName}] [${logContext.endpointName}] - No mapping found for error code $code")
+        InternalError
+      }
     }
 
     downstreamResponseWrapper match {

--- a/app/v2/support/DownstreamResponseMappingSupport.scala
+++ b/app/v2/support/DownstreamResponseMappingSupport.scala
@@ -38,9 +38,15 @@ trait DownstreamResponseMappingSupport {
   final def mapDownstreamErrors[A](errorCodeMap: PartialFunction[String, MtdError])(downstreamResponseWrapper: ResponseWrapper[DownstreamError])(
       implicit logContext: EndpointLogContext): ErrorWrapper = {
 
-    lazy val defaultErrorCodeMapping: String => MtdError = { code =>
-      logger.warn(s"[${logContext.controllerName}] [${logContext.endpointName}] - No mapping found for error code $code")
-      InternalError
+    lazy val defaultErrorCodeMapping: String => MtdError = {
+      case "UNMATCHED_STUB_ERROR" => {
+        logger.warn(s"[${logContext.controllerName}] [${logContext.endpointName}] - No matching stub was found")
+        RuleIncorrectGovTestScenarioError
+      }
+      case code => {
+        logger.warn(s"[${logContext.controllerName}] [${logContext.endpointName}] - No mapping found for error code $code")
+        InternalError
+      }
     }
 
     downstreamResponseWrapper match {

--- a/test/v1/support/DownstreamResponseMappingSupportSpec.scala
+++ b/test/v1/support/DownstreamResponseMappingSupportSpec.scala
@@ -69,7 +69,7 @@ class DownstreamResponseMappingSupportSpec extends UnitSpec {
       }
     }
 
-    "ifs returns UNMATCHED_STUB_ERROR" must {
+    "downstream returns UNMATCHED_STUB_ERROR" must {
       "return an incorrectGovTestScenario error" in {
         mapping.mapDownstreamErrors(errorCodeMap)(
           ResponseWrapper(correlationId, DownstreamErrors.single(DownstreamErrorCode("UNMATCHED_STUB_ERROR")))) shouldBe

--- a/test/v1/support/DownstreamResponseMappingSupportSpec.scala
+++ b/test/v1/support/DownstreamResponseMappingSupportSpec.scala
@@ -46,9 +46,10 @@ class DownstreamResponseMappingSupportSpec extends UnitSpec {
   object ErrorBvr extends MtdError("msg", "bvr", BAD_REQUEST)
 
   val errorCodeMap: PartialFunction[String, MtdError] = {
-    case "ERR1" => Error1
-    case "ERR2" => Error2
-    case "DS"   => InternalError
+    case "ERR1"                 => Error1
+    case "ERR2"                 => Error2
+    case "DS"                   => InternalError
+    case "UNMATCHED_STUB_ERROR" => RuleIncorrectGovTestScenarioError
   }
 
   "mapping Downstream errors" when {
@@ -65,6 +66,14 @@ class DownstreamResponseMappingSupportSpec extends UnitSpec {
           mapping.mapDownstreamErrors(errorCodeMap)(ResponseWrapper(correlationId, DownstreamErrors.single(DownstreamErrorCode("UNKNOWN")))) shouldBe
             ErrorWrapper(correlationId, InternalError)
         }
+      }
+    }
+
+    "ifs returns UNMATCHED_STUB_ERROR" must {
+      "return an incorrectGovTestScenario error" in {
+        mapping.mapDownstreamErrors(errorCodeMap)(
+          ResponseWrapper(correlationId, DownstreamErrors.single(DownstreamErrorCode("UNMATCHED_STUB_ERROR")))) shouldBe
+          ErrorWrapper(correlationId, RuleIncorrectGovTestScenarioError)
       }
     }
 

--- a/test/v2/support/DownstreamResponseMappingSupportSpec.scala
+++ b/test/v2/support/DownstreamResponseMappingSupportSpec.scala
@@ -43,9 +43,10 @@ class DownstreamResponseMappingSupportSpec extends UnitSpec {
   object ErrorBvr extends MtdError("msg", "bvr", BAD_REQUEST)
 
   val errorCodeMap: PartialFunction[String, MtdError] = {
-    case "ERR1" => Error1
-    case "ERR2" => Error2
-    case "DS"   => InternalError
+    case "ERR1"                 => Error1
+    case "ERR2"                 => Error2
+    case "DS"                   => InternalError
+    case "UNMATCHED_STUB_ERROR" => RuleIncorrectGovTestScenarioError
   }
 
   "mapping Downstream errors" when {
@@ -62,6 +63,14 @@ class DownstreamResponseMappingSupportSpec extends UnitSpec {
           mapping.mapDownstreamErrors(errorCodeMap)(ResponseWrapper(correlationId, DownstreamErrors.single(DownstreamErrorCode("UNKNOWN")))) shouldBe
             ErrorWrapper(correlationId, InternalError)
         }
+      }
+    }
+
+    "ifs returns UNMATCHED_STUB_ERROR" must {
+      "return an incorrectGovTestScenario error" in {
+        mapping.mapDownstreamErrors(errorCodeMap)(
+          ResponseWrapper(correlationId, DownstreamErrors.single(DownstreamErrorCode("UNMATCHED_STUB_ERROR")))) shouldBe
+          ErrorWrapper(correlationId, RuleIncorrectGovTestScenarioError)
       }
     }
 

--- a/test/v2/support/DownstreamResponseMappingSupportSpec.scala
+++ b/test/v2/support/DownstreamResponseMappingSupportSpec.scala
@@ -66,7 +66,7 @@ class DownstreamResponseMappingSupportSpec extends UnitSpec {
       }
     }
 
-    "ifs returns UNMATCHED_STUB_ERROR" must {
+    "downstream returns UNMATCHED_STUB_ERROR" must {
       "return an incorrectGovTestScenario error" in {
         mapping.mapDownstreamErrors(errorCodeMap)(
           ResponseWrapper(correlationId, DownstreamErrors.single(DownstreamErrorCode("UNMATCHED_STUB_ERROR")))) shouldBe


### PR DESCRIPTION
When updating the downstream response mapping for this API, the code wasn't located in app/support but in the version folders this time so I needed to add them individually.