### PR TITLE
MTDSA-22948: Deprecate APIs After Release 11

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -79,7 +79,7 @@ api {
   # The status of the version of the API for the API Platform.
   1.0 {
     status = "DEPRECATED"
-    deprecatedOn = "03/05/2023"
+    deprecatedOn = "2023-05-03"
     link = "https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/obligations-api/1.0/oas/page"
     endpoints.enabled = true
   }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -80,7 +80,6 @@ api {
   1.0 {
     status = "DEPRECATED"
     deprecatedOn = "2023-05-03"
-    link = "https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/obligations-api/1.0/oas/page"
     endpoints.enabled = true
   }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -78,7 +78,9 @@ play.modules.enabled += "config.DIModule"
 api {
   # The status of the version of the API for the API Platform.
   1.0 {
-    status = "ALPHA"
+    status = "DEPRECATED"
+    deprecatedOn = "03/05/2023"
+    link = "https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/obligations-api/1.0/oas/page"
     endpoints.enabled = true
   }
 

--- a/it/config/DocumentationControllerISpec.scala
+++ b/it/config/DocumentationControllerISpec.scala
@@ -58,7 +58,7 @@ class DocumentationControllerISpec extends IntegrationBaseSpec {
     |      "versions":[
     |         {
     |            "version":"1.0",
-    |            "status":"ALPHA",
+    |            "status":"DEPRECATED",
     |            "endpointsEnabled":true
     |         },
     |         {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,7 +17,7 @@
 resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build"     % "3.20.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build"     % "3.21.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.4.0")
 
 addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,7 +18,7 @@ resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefac
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build"     % "3.21.0")
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.4.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.5.0")
 
 addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.1")
 


### PR DESCRIPTION
- Adds deprecatedOn and link fields to the application.conf file.
- Modifies status from “ALPHA” to “DEPRECATED”